### PR TITLE
Add invoiceItems and support for signing extraData to beam checkout

### DIFF
--- a/theme/src/components/checkoutForm/paymentForm/index.js
+++ b/theme/src/components/checkoutForm/paymentForm/index.js
@@ -58,7 +58,13 @@ export default class PaymentForm extends React.Component {
 	}
 
 	render() {
-		const { gateway, shopSettings, onPayment, onCreateToken } = this.props;
+		const {
+			gateway,
+			cart,
+			shopSettings,
+			onPayment,
+			onCreateToken
+		} = this.props;
 		const { formSettings, loading } = this.state;
 
 		if (loading) {
@@ -90,6 +96,7 @@ export default class PaymentForm extends React.Component {
 						<div className="payment-form">
 							<BeamButton
 								formSettings={formSettings}
+								cart={cart}
 								shopSettings={shopSettings}
 								onPayment={onPayment}
 							/>

--- a/theme/src/components/checkoutForm/stepPayment.js
+++ b/theme/src/components/checkoutForm/stepPayment.js
@@ -38,6 +38,7 @@ const CheckoutStepPayment = props => {
 					<PaymentForm
 						gateway={payment_method_gateway}
 						amount={grand_total}
+						cart={cart}
 						shopSettings={settings}
 						onPayment={handleSuccessPayment}
 						inputClassName={inputClassName}


### PR DESCRIPTION
This adds to the receipt all the data needed for showing invoice details and merchant information within beam state channels, and  previewing which transaction we are reviewing within beam reviews.